### PR TITLE
fix: 改正DM和DJI电机的反转处理逻辑

### DIFF
--- a/src/librm/device/actuator/dji_motor.hpp
+++ b/src/librm/device/actuator/dji_motor.hpp
@@ -294,6 +294,11 @@ class DjiMotor : public CanDevice, protected DjiMotorBase {
     this->rpm_ = (msg->data[2] << 8) | msg->data[3];
     this->current_ = (msg->data[4] << 8) | msg->data[5];
     this->temperature_ = msg->data[6];
+    if (reversed_) {
+      this->encoder = this->kMaxEncoderValue - this->encoder;
+      this->rpm_ = -this->rpm_;
+      this->current = -this->current_;
+    }
   }
 
   u16 id_{};         ///< 电机ID

--- a/src/librm/device/actuator/dm_motor.hpp
+++ b/src/librm/device/actuator/dm_motor.hpp
@@ -240,6 +240,11 @@ class DmMotor final : public CanDevice {
     torque_ = IntToFloat(t_int, -settings_.t_max, settings_.t_max, 12);
     mos_temperature_ = msg->data[6];
     coil_temperature_ = msg->data[7];
+    if (reversed_) {
+      position_ = -position_;
+      speed_ = -speed_;
+      torque_ = -torque_;
+    }
   }
 
   DmMotorSettings<control_mode> settings_{};


### PR DESCRIPTION
反转处理应该将电机返回值中和命令值中所有有向标量取反。